### PR TITLE
Add libvpx to brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Homebrew only installs various plugins if explicitly enabled, so some extra
 $ brew install gstreamer gst-plugins-base gst-plugins-good \
       gst-plugins-bad gst-plugins-ugly gst-libav gst-rtsp-server \
       --with-orc -with-libogg --with-opus --with-pango --with-theora \
-      --with-libvorbis
+      --with-libvorbis --with-libvpx
 ```
 
 If you wish to install the gstreamer-player sub-crate, make sure the


### PR DESCRIPTION
brew install gst-plugins-good does not include libvpx by default causing the rtpfecserver example to fail as it uses vp8enc